### PR TITLE
Add terraform as a dialect of hcl

### DIFF
--- a/grep_ast/parsers.py
+++ b/grep_ast/parsers.py
@@ -48,6 +48,7 @@ PARSERS = {
     ".scala": "scala",
     ".sql": "sql",
     ".sqlite": "sqlite",
+    ".tf": "hcl",
     ".toml": "toml",
     ".tsq": "tsq",
     ".tsx": "typescript",


### PR DESCRIPTION
Issue https://github.com/Aider-AI/aider/issues/3159 provides a tags.scm that works with terraform files for generating a repomap.   This PR itroduces parsing `.tf` files with the hcl grammar.