### PR TITLE
Add apache classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(
             "gast=grep_ast.main:main",
         ],
     },
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License"
+    ],
 )


### PR DESCRIPTION
This adds a pypi [classifier](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) to specify this package is using the apache license. This came up as grep-ast is a dependency of [aider-chat](https://github.com/Aider-AI/aider/blob/1f4a63d6db59a5c2f975ae4eac66511dee27b809/requirements.txt#L66) and we have tooling to mirror and check the license of pypi packages using this classifier